### PR TITLE
Provide get_params() and get_json() methods.

### DIFF
--- a/limonado/__init__.py
+++ b/limonado/__init__.py
@@ -1,5 +1,7 @@
 # -*- coding: utf-8 -*-
 
+import warnings
+
 from .application import WebAPI
 from .cli import run_cli
 from .endpoints import Endpoint
@@ -21,3 +23,6 @@ __all__ = [
     "validate_request",
     "validate_response",
 ]
+
+# Make sure that DeprecationWarning always gets printed.
+warnings.filterwarnings("always", category=DeprecationWarning, module=__name__)

--- a/limonado/validation/__init__.py
+++ b/limonado/validation/__init__.py
@@ -5,11 +5,9 @@ import logging
 
 import jsonschema
 from tornado.concurrent import is_future
-from tornado.escape import json_decode
 from tornado.gen import coroutine
 
 from ..exceptions import APIError
-from ..utils._params import extract_params
 from ..utils.decorators import container
 from ..utils.validators import validate_duration
 
@@ -32,25 +30,10 @@ def validate_request(params_schema=None, json_schema=None):
 
         @wraps(rh_method)
         def _wrapper(self, *args, **kwargs):
-            if params_schema is None:
-                params = {}
-            else:
-                params = extract_params(self.request.arguments, params_schema)
-                _validate_request_data(params, params_schema)
+            if params_schema is not None:
+                self.params = self.get_params(params_schema)
 
-            if not self.request.body:
-                json = None
-            else:
-                try:
-                    json = json_decode(self.request.body.decode("utf-8"))
-                except ValueError:
-                    raise APIError(400, "Malformed JSON")
-
-            if json_schema is not None:
-                _validate_request_data(json, json_schema)
-
-            self.params = params
-            self.json = json
+            self.json = self.get_json(schema=json_schema)
             return rh_method(self, *args, **kwargs)
 
         return _wrapper
@@ -86,7 +69,7 @@ def validate_response(schema):
     return _validate
 
 
-def _validate_request_data(data, schema):
+def validate_request_data(data, schema):
     try:
         jsonschema.validate(data, schema, format_checker=format_checker)
     except jsonschema.ValidationError as error:

--- a/limonado/validation/__init__.py
+++ b/limonado/validation/__init__.py
@@ -2,6 +2,7 @@
 
 from functools import wraps
 import logging
+import warnings
 
 import jsonschema
 from tornado.concurrent import is_future
@@ -24,6 +25,9 @@ format_checker.checks("duration")(validate_duration)
 
 
 def validate_request(params_schema=None, json_schema=None):
+    warnings.warn("`validate_request` is deprecated and will be removed in "
+                  "1.0. Use `get_json` and `get_params` on the request "
+                  "handler instead.", DeprecationWarning)
 
     @container
     def _validate(rh_method):


### PR DESCRIPTION
This pull request addresses shortcomings of the current decorator-based input handling. It aims to add more flexibility to Limonado's input handling while maintaining full backwards compatibility.

## Rationale

Currently, input handling requires the use of the `validate_request` decorator. I see two issues with this:

1. It doesn't follow the principle of least astonishment. The attributes `self.json` (JSON body) and `self.params` (query parameters) are `None` unless `validate_request` is used. This is somewhat surprising, as the existence of the input data should be independent of it's validation.

```
# no decorator
def post(self):
    json_body = self.json  # None
    query_params = self.params  # None
```

(To better communicate this behaviour, attributes could be renamed to e.g. `self.validated_json` and `self.validated_params`. However, this option will not be pursued here in lieu of a more flexible approach.)

It it easy to fix this for `self.json`. Unfortunately, this does not hold for `self.params`. Limonado's parsing of query parameters requires a JSON schema to infer types. This is something Open API does as well, and that I consider a feature rather than a restriction. Otherwise, we would have to go back to using heuristics (true/false -> bool, etc), which are more error-prone and less expressive.

2. It's less flexible. Sometimes, the contents of the body may depend on logic that cannot be modeled within the scope of a decorator (e.g. settings, query parameters, user permissions).

## Proposed Changes

This pull request adds two new methods to request handlers: `get_json(schema=None)` and `get_params(schema)`:

```
def post(self):
    json_body = self.get_json(schema=MY_BODY_SCHEMA)
    query_params = self.get_params(MY_PARAMS_SCHEMA)
```

Schemas are optional for the body but mandatory for query parameters, which resolves the aforementioned issue of implicitness. In addition to that, schemas may potentially depend on arbitrary logic as we're no longer bound to the scope of the decorator.

No changes are needed for existing code. The implementation is minimal and fully backwards-compatible, and future code may continue to use the decorator-based approach.