### PR TITLE
Move to Tornado 5 for integration with asyncio.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: python
 
 python:
-  - "3.3"
   - "3.4"
   - "3.5"
   - "3.6"

--- a/limonado/endpoints.py
+++ b/limonado/endpoints.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from tornado.gen import Return
 from tornado.gen import coroutine
 
 from .handlers import HealthHandler
@@ -38,7 +37,7 @@ class Endpoint(object):
 
     @coroutine
     def check_health(self):
-        raise Return(Health())
+        return Health()
 
 
 class RootEndpoint(Endpoint):

--- a/limonado/handlers.py
+++ b/limonado/handlers.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 
 from tornado.escape import json_encode
-from tornado.gen import Return
 from tornado.gen import coroutine
 from tornado.web import RequestHandler
 
@@ -102,7 +101,7 @@ class HealthHandler(EndpointHandler):
         if not health.ok:
             self.set_status(503)
 
-        raise Return(health.details)
+        return health.details
 
     def check_health(self):
         return self.endpoint.check_health()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 jsonschema==2.5.1
 python-dateutil>=2.5,<2.6
 strict_rfc3339==0.5
-tornado>=4.0,<5.0
+tornado>=5.0,<6.0

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,6 @@ def setup_package():
             "Operating System :: OS Independent",
             "Topic :: Internet :: WWW/HTTP",
             "Programming Language :: Python :: 3",
-            "Programming Language :: Python :: 3.3",
             "Programming Language :: Python :: 3.4",
             "Programming Language :: Python :: 3.5",
             "Programming Language :: Python :: 3.6",

--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,7 @@ def setup_package():
             "jsonschema==2.5.1",
             "python-dateutil>=2.5,<2.6",
             "strict_rfc3339==0.5",
-            "tornado>=4.0,<5.0"
+            "tornado>=5.0,<6.0"
         ]
     )
 


### PR DESCRIPTION
From version 5 on, Tornado uses Python 3's IO loop library (`asyncio`). This means we can start to use `async/await` instead of the `coroutine/yield` hack without further ado.

It also addresses another important drawback of using `asyncìo` with Tornado 4: Tornado's `run_on_executor` does not work with `asyncio` and never will. Version 5 adds a new function `IOLoop.run_in_executor` that can be used instead.

I'm using Limonado with Tornado 5 for a new project and haven't had any issues so far.

Reference: http://www.tornadoweb.org/en/stable/releases/v5.0.0.html