### PR TITLE
Provide function for registering custom JSON schema formats.

### DIFF
--- a/limonado/validation/__init__.py
+++ b/limonado/validation/__init__.py
@@ -22,7 +22,13 @@ __all__ = [
 log = logging.getLogger(__name__)
 
 format_checker = jsonschema.FormatChecker()
-format_checker.checks("duration")(validate_duration)
+
+
+def register_format(name, validator):
+    format_checker.checks(name)(validator)
+
+
+register_format("duration", validate_duration)
 
 
 def validate_request(params_schema=None, json_schema=None):


### PR DESCRIPTION
JSON schema allows to define custom formats. This pull request adds a public function to register custom formats to Limonado's validator. Example usage:

```
import limonado.validation
limonado.validation.register_format("date-expr", validate_date_expr)
```

Schemas may now use the new format:

```
{
    "properties": {
        "min_date": {
            "type": "string",
            "format": "date-expr"
        },
        "max_date": {
            "type": "string",
            "format": "date-expr"
        }
    }
}
```